### PR TITLE
Fix revenue parsing in merge script

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Este repositorio incluye un script utilitario para combinar archivos de medios y
 *   `--revenue-column`: Nombre de la columna de ingresos (por defecto: `revenue`)
 *   `--date-format`: Formato de la columna de fecha. Si no se especifica, el
     script intentará inferirlo automáticamente.
+*   Las columnas numéricas se convierten automáticamente a valores numéricos
+    cuando es posible para evitar errores de tipado.
 
 ### Ejemplo de uso
 

--- a/scripts/merge_inputs.py
+++ b/scripts/merge_inputs.py
@@ -76,6 +76,8 @@ def load_table(path: str, sep: str, decimal: str) -> pd.DataFrame:
         df = pd.read_csv(path, sep=sep, decimal=decimal)
     # Drop common index columns written by pandas.to_csv
     df = df.loc[:, ~df.columns.str.contains("^Unnamed")]
+    # Ensure numeric columns are read as numeric when possible
+    df = df.apply(pd.to_numeric, errors="ignore")
     return df
 
 
@@ -156,6 +158,9 @@ def main() -> None:
         args.population_column,
         args.compute_per_conversion,
     )
+
+    # Convert numeric-like columns to proper numeric dtypes before saving
+    merged = merged.apply(pd.to_numeric, errors="ignore")
 
     merged.to_csv(args.output, index=False)
 


### PR DESCRIPTION
## Summary
- coerce numeric columns when merging input data
- document automatic numeric conversion in README

## Testing
- `pytest`