### PR TITLE
Fix revenue_per_kpi type check

### DIFF
--- a/meridian/data/input_data.py
+++ b/meridian/data/input_data.py
@@ -492,13 +492,18 @@ class InputData:
     if (self.kpi.values < 0).any():
       raise ValueError("KPI values must be non-negative.")
 
-    if (
-        self.revenue_per_kpi is not None
-        and (self.revenue_per_kpi.values <= 0).all()
-    ):
-      raise ValueError(
-          "Revenue per KPI values must not be all zero or negative."
-      )
+    if self.revenue_per_kpi is not None:
+      try:
+        revenue_values = self.revenue_per_kpi.astype(float).values
+      except (ValueError, TypeError) as e:
+        raise TypeError(
+            "`revenue_per_kpi` must contain numeric values"
+        ) from e
+
+      if (revenue_values <= 0).all():
+        raise ValueError(
+            "Revenue per KPI values must not be all zero or negative."
+        )
 
   def _validate_names(self):
     """Verifies that the names of the data arrays are correct."""

--- a/scripts/merge_inputs.py
+++ b/scripts/merge_inputs.py
@@ -77,7 +77,7 @@ def load_table(path: str, sep: str, decimal: str) -> pd.DataFrame:
     # Drop common index columns written by pandas.to_csv
     df = df.loc[:, ~df.columns.str.contains("^Unnamed")]
     # Ensure numeric columns are read as numeric when possible
-    df = df.apply(pd.to_numeric, errors="ignore")
+    df = df.apply(pd.to_numeric, errors="coerce")
     return df
 
 
@@ -160,7 +160,7 @@ def main() -> None:
     )
 
     # Convert numeric-like columns to proper numeric dtypes before saving
-    merged = merged.apply(pd.to_numeric, errors="ignore")
+    merged = merged.apply(pd.to_numeric, errors="coerce")
 
     merged.to_csv(args.output, index=False)
 


### PR DESCRIPTION
## Summary
- convert `revenue_per_kpi` values to numeric before validation so TypeError is avoided
- coerce columns to numeric in `merge_inputs.py`

## Testing
- `pytest`